### PR TITLE
support any button as trigger or action(s)

### DIFF
--- a/projects/fab-speed-dial/src/lib/fab-speed-dial.ts
+++ b/projects/fab-speed-dial/src/lib/fab-speed-dial.ts
@@ -29,7 +29,7 @@ export type AnimationMode = 'fling' | 'scale';
 @Component({
     selector: 'eco-fab-speed-dial-actions',
     template: `
-        <ng-content select="[mat-mini-fab]" *ngIf="miniFabVisible"></ng-content>`,
+        <ng-content select="button" *ngIf="miniFabVisible"></ng-content>`,
 })
 export class EcoFabSpeedDialActionsComponent implements AfterContentInit {
     private _parent: EcoFabSpeedDialComponent;
@@ -329,7 +329,7 @@ export class EcoFabSpeedDialComponent implements OnDestroy, AfterContentInit {
 @Component({
     selector: 'eco-fab-speed-dial-trigger',
     template: `
-        <ng-content select="[mat-fab]"></ng-content>`,
+        <ng-content select="button"></ng-content>`,
 })
 export class EcoFabSpeedDialTriggerComponent {
     private _parent: EcoFabSpeedDialComponent;


### PR DESCRIPTION
there is already a distinction between the trigger and the actions, select the button allows users to use different buttons.

E.g.: 
mat-mini-fab as trigger
mat-icon-button as actions

(For cleanness the variables containing 'fab' could be renamed)